### PR TITLE
vendor: Add support for BFQIO cgroups

### DIFF
--- a/misc/libbfqio/Android.bp
+++ b/misc/libbfqio/Android.bp
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2017 The LineageOS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+cc_library_headers {
+    name: "libbfqio_headers",
+    vendor_available: true,
+    export_include_dirs: ["include"],
+}
+
+cc_defaults {
+    name: "libbfqio_defaults",
+    srcs: [
+        "bfqio.c",
+    ],
+
+    shared_libs: [
+        "libcutils",
+        "liblog",
+    ],
+    header_libs: [
+        "libbfqio_headers",
+    ],
+    export_header_lib_headers: ["libbfqio_headers"],
+
+    cflags: [
+        "-Werror",
+        "-Wall",
+        "-Wextra",
+    ],
+}
+
+cc_library {
+    name: "libbfqio",
+    vendor_available: true,
+    defaults: ["libbfqio_defaults"],
+}
+
+cc_library {
+    name: "libbfqio_vendor",
+    vendor: true,
+    defaults: ["libbfqio_defaults"],
+}

--- a/misc/libbfqio/bfqio.c
+++ b/misc/libbfqio/bfqio.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "bfqio"
+
+#include <fcntl.h>
+#include <cutils/iosched_policy.h>
+#include <cutils/log.h>
+#include <pthread.h>
+#include <sys/stat.h>
+
+static int __rtio_cgroup_supported = -1;
+static pthread_once_t __rtio_init_once = PTHREAD_ONCE_INIT;
+
+static void __initialize_rtio(void) {
+    if (!access("/dev/bfqio/tasks", W_OK) || !access("/dev/bfqio/rt-display/tasks", W_OK)) {
+        __rtio_cgroup_supported = 1;
+    } else {
+        __rtio_cgroup_supported = 0;
+    }
+}
+
+int android_set_rt_ioprio(int tid, int rt) {
+    int fd = -1, rc = -1;
+
+    pthread_once(&__rtio_init_once, __initialize_rtio);
+    if (__rtio_cgroup_supported != 1) {
+        return -1;
+    }
+
+    if (rt) {
+        fd = open("/dev/bfqio/rt-display/tasks", O_WRONLY | O_CLOEXEC);
+    } else {
+        fd = open("/dev/bfqio/tasks", O_WRONLY | O_CLOEXEC);
+    }
+
+    if (fd < 0) {
+        return -1;
+    }
+
+#ifdef HAVE_GETTID
+    if (tid == 0) {
+        tid = gettid();
+    }
+#endif
+
+    // specialized itoa -- works for tid > 0
+    char text[22];
+    char *end = text + sizeof(text) - 1;
+    char *ptr = end;
+    *ptr = '\0';
+    while (tid > 0) {
+        *--ptr = '0' + (tid % 10);
+        tid = tid / 10;
+    }
+
+    rc = write(fd, ptr, end - ptr);
+    if (rc < 0) {
+        /*
+         * If the thread is in the process of exiting,
+         * don't flag an error
+         */
+        if (errno == ESRCH) {
+            rc = 0;
+        } else {
+            SLOGV("android_set_rt_ioprio failed to write '%s' (%s); fd=%d\n",
+                  ptr, strerror(errno), fd);
+        }
+    }
+
+    close(fd);
+    return rc;
+}

--- a/misc/libbfqio/include/bfqio/bfqio.h
+++ b/misc/libbfqio/include/bfqio/bfqio.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BFQIO_H
+#define __BFQIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int android_set_rt_ioprio(int pid, int rt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BFQIO_H */


### PR DESCRIPTION
 * Introduce a standalone libbfqio to be picked by inputflinger,
   surfaceflinger and display HAL, without extending the VNDK.

 * This commit is based on the following patches:

  From: Steve Kondik <steve@cyngn.com>
  Date: Tue, 08 Sep 2015 02:23:41 -0700

      cutils: Add support for BFQIO cgroups

       * Add support for a custom hierarchy of cgroups on top of the BFQ
         IO scheduler. This allows us to place every thread into the
         right class (realtime/best-effort/idle) with a set up priority
         buckets depending on use case.
       * The benefit of doing this is pretty incredible from an
         interactivity standpoint. Realtime users (display/audio) benefit
         the most, resulting in glitch-free audio and jank-free video.
         Dexopting in the background no longer causes active harm to
         foreground tasks. Other tasks such as account syncing become
         invisible from the user's perspective.
       * Magic bullet? Perhaps.

      Change-Id: I4eb911395364ce46d6dcbff43e94286ded03a97d

  From: Steve Kondik <steve@cyngn.com>
  Date: Sat, 19 Sep 2015 12:43:40 -0700

      cutils: Fix copypasta in ioprio code

      Change-Id: I976693be4a6913ed2090fa32d0f8e4c93657e7e7

  From: Steve Kondik <steve@cyngn.com>
  Date: Sun, 20 Sep 2015 01:08:07 -0700

      cutils: Fix display ioprio

       * A few unwanted items are sneaking into this class resulting in
         system slowdowns. Fixit.

      Change-Id: I29033a38adf2c65535f916135d395d5147afe323

  From: Steve Kondik <steve@cyngn.com>
  Date: Sun, 20 Sep 2015 03:00:54 -0700

      cutils: Clean up ioprio grouping

       * It's now better understood what's happening system-wide due to these
         changes, so clean up the stuff which is not necessary and/or
         potentially harmful.

      Change-Id: I72178770844c1ac388a0b424b12cdc49042aec87

  From: Steve Kondik <steve@cyngn.com>
  Date: Sun, 20 Sep 2015 17:36:54 -0700

      cutils: Remove ioprio magic

       * ..and replace it with something we can call explictly where it is
         required in order to achieve the same goodness without the badness.

      Change-Id: I605b3acbc56ce82663dd6f1c9f3320d0ab75e178

  From: Zhao Wei Liew <zhaoweiliew@gmail.com>
  Date: Thu, 08 Sep 2016 20:01:29 +0800

      cutils: iosched_policy: Access BFQIO cgroup in /dev/bfqio

      AOSP doesn't mount cgroups in /sys/fs/cgroup, but in /dev/.
      Follow what AOSP does.

      Change-Id: I40d2241e3e5c41612d3a54d22981d3250f8b1ed6

Change-Id: I7d42bd6bb9176724c1e5687de14946923150ae89